### PR TITLE
Caching of a series data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: java
 jdk:
   - oraclejdk8
-before_install:
-  - cat ~/.m2/settings.xml # check before
-  # https://github.com/travis-ci/travis-ci/issues/4629
-  - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
-  - cat ~/.m2/settings.xml # check after
-install: true
-script: mvn clean install
+script: mvn -fae -U -B clean install -P snapshot-dist
+cache:
+  directories
+    - $HOME/.m2
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-  - openjdk8
 before_install:
   - cat ~/.m2/settings.xml # check before
   # https://github.com/travis-ci/travis-ci/issues/4629

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk:
+  - oraclejdk8
+  - openjdk8
+before_install:
+  - cat ~/.m2/settings.xml # check before
+  # https://github.com/travis-ci/travis-ci/issues/4629
+  - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
+  - cat ~/.m2/settings.xml # check after
+install: true
+script: mvn clean install

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Cache for Series REST API
+A caching module for Series REST API.
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -45,16 +45,62 @@
         </dependency>
     </dependencies>
          
+    <build>
+    </build>
+         
+    <profiles>
+        <profile>
+            <id>snapshot-dist</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-enforcer-plugin</artifactId>
+                            <configuration>
+                                <rules>
+                                    <requireNoRepositories>
+                                        <allowedRepositories>
+                                            <id>geotools</id>
+                                            <id>n52-releases</id>
+                                            <id>n52-snapshots</id>
+                                            <id>sonatype-nexus-snapshots</id>
+                                        </allowedRepositories>
+                                    </requireNoRepositories>
+                                </rules>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+
+             <repositories>
+                 <repository>
+                     <id>n52-releases</id>
+                     <name>52n Releases</name>
+                     <url>http://52north.org/maven/repo/releases/</url>
+                 </repository>
+                 <repository>
+                     <id>n52-snapshots</id>
+                     <name>52n Snapshots</name>
+                     <url>http://52north.org/maven/repo/snapshots/</url>
+                 </repository>
+                 <repository>
+                     <id>geotools</id>
+                     <name>Open Source Geospatial Foundation Repository</name>
+                     <url>http://download.osgeo.org/webdav/geotools/</url>
+                     <!--<url>https://boundless.artifactoryonline.com/boundless/main</url> -->
+                     <!--<url>http://repo.boundlessgeo.com/main/</url> -->
+                 </repository>
+             </repositories>
+        </profile>                  
+    </profiles>
+         
     <repositories>
         <repository>
             <id>n52-releases</id>
             <name>52n Releases</name>
             <url>http://52north.org/maven/repo/releases/</url>
-        </repository>
-        <repository>
-            <id>n52-snapshots</id>
-            <name>52n Snapshots</name>
-            <url>http://52north.org/maven/repo/snapshots/</url>
         </repository>
         <repository>
             <id>geotools</id>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,11 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>rest</artifactId>
+            <artifactId>spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,5 +44,25 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
+         
+    <repositories>
+        <repository>
+            <id>n52-releases</id>
+            <name>52n Releases</name>
+            <url>http://52north.org/maven/repo/releases/</url>
+        </repository>
+        <repository>
+            <id>n52-snapshots</id>
+            <name>52n Snapshots</name>
+            <url>http://52north.org/maven/repo/snapshots/</url>
+        </repository>
+        <repository>
+            <id>geotools</id>
+            <name>Open Source Geospatial Foundation Repository</name>
+            <url>http://download.osgeo.org/webdav/geotools/</url>
+            <!--<url>https://boundless.artifactoryonline.com/boundless/main</url> -->
+            <!--<url>http://repo.boundlessgeo.com/main/</url> -->
+        </repository>
+    </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.n52</groupId>
+        <artifactId>parent</artifactId>
+        <version>7</version>
+    </parent>
+    <groupId>org.n52.series-api</groupId>
+    <artifactId>series-rest-api-cache</artifactId>
+    <name>Series REST API - Caching module</name>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+
+    <organization>
+        <name>52North Initiative for Geospatial Open Source Software GmbH</name>
+        <url>http://52north.org</url>
+    </organization>
+
+    <developers>
+        <developer>
+            <id>antego</id>
+            <name>Anton Egorov</name>
+            <email>a.egorov@52north.org</email>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License, Version 2.0</name>
+            <url>http://www.gnu.de/documents/gpl-2.0.en.html</url>
+        </license>
+    </licenses>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,10 @@
 
     <licenses>
         <license>
-            <name>GNU General Public License, Version 2.0</name>
-            <url>http://www.gnu.de/documents/gpl-2.0.en.html</url>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.n52</groupId>
-        <artifactId>parent</artifactId>
-        <version>7</version>
+        <groupId>org.n52.series-api</groupId>
+        <artifactId>series-rest-api</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.n52.series-api</groupId>
-    <artifactId>series-rest-api-cache</artifactId>
+    <artifactId>cache</artifactId>
     <name>Series REST API - Caching module</name>
-    <version>1.0.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
 
     <organization>
@@ -35,5 +33,12 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>rest</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,5 +34,4 @@
         </license>
     </licenses>
 
-
 </project>

--- a/src/main/java/org/n52/cache/CachingDataService.java
+++ b/src/main/java/org/n52/cache/CachingDataService.java
@@ -29,25 +29,66 @@
 
 package org.n52.cache;
 
+import org.n52.io.request.IoParameters;
 import org.n52.io.request.RequestParameterSet;
+import org.n52.io.response.OutputCollection;
+import org.n52.io.response.ParameterOutput;
 import org.n52.io.response.dataset.AbstractValue;
 import org.n52.io.response.dataset.Data;
 import org.n52.io.response.dataset.DataCollection;
 import org.n52.series.spi.srv.DataService;
+import org.n52.series.spi.srv.ParameterService;
 import org.n52.series.spi.srv.RawDataService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * TODO: JavaDoc
  *
  */
-public class CachingDataService implements DataService<Data<AbstractValue< ? >>> {
+public class CachingDataService extends ParameterService<ParameterOutput>
+        implements DataService<Data<AbstractValue< ? >>> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CachingDataService.class);
 
-    @Override
-    public DataCollection<Data<AbstractValue< ? >>> getData(RequestParameterSet parameters) {
-        return null;
+    private ParameterService<ParameterOutput> parameterService;
+
+    private DataService<Data<AbstractValue< ? >>> dataService;
+
+    private DataCache cache;
+
+    public CachingDataService(ParameterService<ParameterOutput> parameterService,
+                              DataService<Data<AbstractValue< ? >>> dataService,
+                              DataCache cache) {
+        this.parameterService = parameterService;
+        this.dataService = dataService;
+        this.cache = cache;
     }
 
+    @Override
+    public OutputCollection<ParameterOutput> getExpandedParameters(IoParameters query) {
+        return parameterService.getExpandedParameters(query);
+    }
+
+    @Override
+    public OutputCollection<ParameterOutput> getCondensedParameters(IoParameters query) {
+        return parameterService.getCondensedParameters(query);
+    }
+
+    @Override
+    public OutputCollection<ParameterOutput> getParameters(String[] items, IoParameters query) {
+        return parameterService.getParameters(items, query);
+    }
+
+    @Override
+    public ParameterOutput getParameter(String item, IoParameters query) {
+        return parameterService.getParameter(item, query);
+    }
+
+    @Override
+    public boolean exists(String id, IoParameters parameters) {
+        return parameterService.exists(id, parameters);
+    }
 
     @Override
     public boolean supportsRawData() {
@@ -57,5 +98,10 @@ public class CachingDataService implements DataService<Data<AbstractValue< ? >>>
     @Override
     public RawDataService getRawDataService() {
         return null;
+    }
+
+    @Override
+    public DataCollection<Data<AbstractValue<?>>> getData(RequestParameterSet parameters) {
+        return dataService.getData(parameters);
     }
 }

--- a/src/main/java/org/n52/cache/CachingDataService.java
+++ b/src/main/java/org/n52/cache/CachingDataService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015-2017 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public License
+ * version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+package org.n52.cache;
+
+import org.n52.io.request.RequestParameterSet;
+import org.n52.io.response.dataset.AbstractValue;
+import org.n52.io.response.dataset.Data;
+import org.n52.io.response.dataset.DataCollection;
+import org.n52.series.spi.srv.DataService;
+import org.n52.series.spi.srv.RawDataService;
+
+/**
+ * TODO: JavaDoc
+ *
+ */
+public class CachingDataService implements DataService<Data<AbstractValue< ? >>> {
+
+
+    @Override
+    public DataCollection<Data<AbstractValue< ? >>> getData(RequestParameterSet parameters) {
+        return null;
+    }
+
+
+    @Override
+    public boolean supportsRawData() {
+        return false;
+    }
+
+    @Override
+    public RawDataService getRawDataService() {
+        return null;
+    }
+}

--- a/src/main/java/org/n52/cache/DataCache.java
+++ b/src/main/java/org/n52/cache/DataCache.java
@@ -1,0 +1,15 @@
+package org.n52.cache;
+
+import org.n52.io.request.RequestParameterSet;
+import org.n52.io.response.dataset.AbstractValue;
+import org.n52.io.response.dataset.Data;
+import org.n52.io.response.dataset.DataCollection;
+
+import java.util.Optional;
+
+public interface DataCache {
+    boolean isDataCached(RequestParameterSet parameters);
+    Optional<DataCollection<Data<AbstractValue< ? >>>> getData(RequestParameterSet parameters);
+    void putDataForParameters(RequestParameterSet parameters, DataCollection<Data<AbstractValue< ? >>> data);
+
+}

--- a/src/main/java/org/n52/cache/DataCache.java
+++ b/src/main/java/org/n52/cache/DataCache.java
@@ -9,7 +9,9 @@ import java.util.Optional;
 
 public interface DataCache {
     boolean isDataCached(RequestParameterSet parameters);
+
     Optional<DataCollection<Data<AbstractValue< ? >>>> getData(RequestParameterSet parameters);
+    
     void putDataForParameters(RequestParameterSet parameters, DataCollection<Data<AbstractValue< ? >>> data);
 
 }


### PR DESCRIPTION
The main part of a current architecture is a proxy class `CachingDataService`. Underneath it uses the implementation of `DataCache` class for storing the data. By changing the `DataCache` implementation it is possible to plug in different databases.